### PR TITLE
Update README.txt

### DIFF
--- a/dsc/README.txt
+++ b/dsc/README.txt
@@ -57,11 +57,11 @@ Prerequisites
 
 
 1. Install the Linux Resource Provider MOF module:
-   A. Extract the nx.zip file into %SystemRoot%\system32\WindowsPowerShell\v1.0\Modules\ such that the directory tree looks like:
-      %SystemRoot%\system32\WindowsPowerShell\v1.0\Modules\nx\nx.psd1
-      %SystemRoot%\system32\WindowsPowerShell\v1.0\Modules\nx\Readme.txt
-      %SystemRoot%\system32\WindowsPowerShell\v1.0\Modules\nx\DSCResources
-      %SystemRoot%\system32\WindowsPowerShell\v1.0\Modules\nx\DSCResources\MSFT_nxFileResource
+   A. Extract the nx.zip file into %programfiles%\WindowsPowerShell\Modules\ such that the directory tree looks like:
+      %programfiles%\WindowsPowerShell\Modules\nx\nx.psd1
+      %programfiles%\WindowsPowerShell\Modules\nx\Readme.txt
+      %programfiles%\WindowsPowerShell\Modules\nx\DSCResources
+      %programfiles%\WindowsPowerShell\Modules\nx\DSCResources\MSFT_nxFileResource
       ...
 
    B. In order to compile a Configuration MOF that uses the DSC for Linux resources, use "Import-DscResource -Module nx" inside a DSC Configuration block.


### PR DESCRIPTION
Suggest putting the module in the %ProgramFiles%\WindowsPowerShell\Modules directory. The modules directory under %systemdir%\system32\windowspowershell\v1.0 is supposed to be reserved for Microsoft official bits; putting 3rd party modules in there is bad juju.